### PR TITLE
Update to Mapbox-iOS-SDK 6.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This Flutter plugin allows to show embedded interactive and customizable vector 
 
 - Install [Flutter](https://flutter.io/get-started/) and validate its installation with `flutter doctor`
 - Clone the repository with `git clone git@github.com:tobrun/flutter-mapbox-gl.git`
-- Add a Mapbox access token to the example app (see next section)
+- Add a public Mapbox access token to the example app (see next section)
+- Add a secret Mapbox access token for downloading the SDK
 - Connect a mobile device or start an emulator, simulator or chrome
 - Locate the id of a the device with `flutter devices`
 - Run the app with `cd flutter_mapbox/example && flutter packages get && flutter run -d {device_id}`
@@ -24,6 +25,17 @@ This project uses Mapbox vector tiles, which requires a Mapbox account and a Map
 The **recommended** way to provide your access token is through the `MapboxMap` constructor's `accessToken` parameter, which is available starting from the v0.8 release. Note that you should always use the same token throughout your entire app.
 
 An alternative method to provide access tokens that was required until the v0.7 release is described in [this wiki article](https://github.com/tobrun/flutter-mapbox-gl/wiki/Mapbox-access-tokens).
+
+### SDK Download token
+
+You must also [configure a secret access token having the Download: read
+scope][https://docs.mapbox.com/ios/maps/guides/install/]. If this configuration
+is not present, an error like the following appears during the iOS build.
+
+```
+[!] Error installing Mapbox-iOS-SDK
+curl: (22) The requested URL returned error: 401 Unauthorized
+```
 
 ## Avoid Android UnsatisfiedLinkError
 

--- a/ios/Classes/MapboxMapController.swift
+++ b/ios/Classes/MapboxMapController.swift
@@ -28,7 +28,7 @@ class MapboxMapController: NSObject, FlutterPlatformView, MGLMapViewDelegate, Ma
     
     init(withFrame frame: CGRect, viewIdentifier viewId: Int64, arguments args: Any?, registrar: FlutterPluginRegistrar) {
         if let args = args as? [String: Any] {
-            if let token = args["accessToken"] as? NSString{
+            if let token = args["accessToken"] as? String {
                 MGLAccountManager.accessToken = token
             }
         }

--- a/ios/mapbox_gl.podspec
+++ b/ios/mapbox_gl.podspec
@@ -16,7 +16,7 @@ A new Flutter plugin.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'MapboxAnnotationExtension', '~> 0.0.1-beta.1'
-  s.dependency 'Mapbox-iOS-SDK', '~> 5.6.0'
+  s.dependency 'Mapbox-iOS-SDK', '~> 6.3.0'
   s.swift_version = '4.2'
   s.ios.deployment_target = '9.0'
 end


### PR DESCRIPTION
The 6.0.0 upgrade had no breaking changes:

> This major release does not include any breaking changes to public
> APIs. We are treating this release as a SEMVER major change because
> our installation instructions have changed.
https://github.com/mapbox/mapbox-gl-native-ios/releases/tag/ios-v6.0.0

I did however need to cast the `accessToken` as a `String` to satisfy
the compiler after this upgrade.

Prior to the upgrade I was seeing crashes from this bug, which was fixed
in 6.2: https://github.com/mapbox/mapbox-gl-native-ios/issues/485

So far I don't see any issues at all after the upgrade.

Developers will need to configure their access token in order to fetch
the mapbox sdk for this an future versions, described here:
https://docs.mapbox.com/ios/maps/guides/install/